### PR TITLE
fixed bug that when migp is put as default arg it produces a type error

### DIFF
--- a/NFACT/NFACT_decomp/setup/args.py
+++ b/NFACT/NFACT_decomp/setup/args.py
@@ -46,7 +46,7 @@ def nfact_args() -> dict:
         "-m",
         "--migp",
         dest="migp",
-        default=1000,
+        default="1000",
         help="MELODIC's Incremental Group-PCA dimensionality (default is 1000)",
     )
     args.add_argument(


### PR DESCRIPTION
1) put default as string