### PR TITLE
fixed thresholding error that caused str>int error

### DIFF
--- a/NFACT/stats/stats_args.py
+++ b/NFACT/stats/stats_args.py
@@ -137,6 +137,7 @@ def comp_loading_args(args: object) -> None:
         "--threshold",
         dest="threshold",
         default=2,
+        type=int,
         help="""
         Threshold components so that component
         loadings reflect connectivity patterns


### PR DESCRIPTION
1) fixed error on nfact stats not putting threshold as int